### PR TITLE
PI-918 Change babel presets to es2015 and react

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,3 @@
 {
-  "presets": ["cf"],
-  "plugins": ["transform-object-assign"]
+  "presets": ["es2015", "react"]
 }

--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,4 @@
 {
-  "presets": ["es2015", "react"]
+  "presets": ["es2015", "react"],
+  "plugins": ["transform-object-assign", "transform-object-rest-spread"]
 }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
   "devDependencies": {
     "babel-core": "^6.1.21",
     "babel-eslint": "^6.0.0",
+    "babel-plugin-transform-object-assign": "^6.8.0",
+    "babel-plugin-transform-object-rest-spread": "^6.19.0",
     "babel-polyfill": "^6.5.0",
     "babel-preset-es2015": "^6.1.18",
     "babel-preset-react": "^6.1.18",

--- a/package.json
+++ b/package.json
@@ -21,9 +21,7 @@
   "devDependencies": {
     "babel-core": "^6.1.21",
     "babel-eslint": "^6.0.0",
-    "babel-plugin-transform-object-assign": "^6.5.0",
     "babel-polyfill": "^6.5.0",
-    "babel-preset-cf": "^1.1.0",
     "babel-preset-es2015": "^6.1.18",
     "babel-preset-react": "^6.1.18",
     "babel-register": "^6.5.2",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "babel-eslint": "^6.0.0",
     "babel-plugin-transform-object-assign": "^6.8.0",
     "babel-plugin-transform-object-rest-spread": "^6.19.0",
-    "babel-polyfill": "^6.5.0",
     "babel-preset-es2015": "^6.1.18",
     "babel-preset-react": "^6.1.18",
     "babel-register": "^6.5.2",

--- a/src/js/test/reducers/activeZoneTest.js
+++ b/src/js/test/reducers/activeZoneTest.js
@@ -1,7 +1,6 @@
 import { expect } from 'chai';
 import { activeZoneReducer } from '../../reducers/activeZone';
 import * as ActionTypes from '../../constants/ActionTypes';
-import 'babel-polyfill'; //Object.Assign
 
 describe('Active Zone Reducer', () => {
     it('should return the initial state', () => {

--- a/src/js/test/reducers/configTest.js
+++ b/src/js/test/reducers/configTest.js
@@ -1,7 +1,6 @@
 import { expect } from 'chai';
 import { configReducer } from '../../reducers/config';
 import * as ActionTypes from '../../constants/ActionTypes';
-import 'babel-polyfill'; //Object.Assign
 
 describe('Config Reducer', () => {
     it('should return the initial state', () => {

--- a/src/js/test/reducers/pluginSettingsTest.js
+++ b/src/js/test/reducers/pluginSettingsTest.js
@@ -1,8 +1,6 @@
 import { expect } from 'chai';
 import { pluginSettingsReducer } from '../../reducers/pluginSettings';
 import * as ActionTypes from '../../constants/ActionTypes';
-import 'babel-polyfill'; //Object.Assign
-
 
 let initialState = {
     result: [],

--- a/src/js/test/reducers/zonePurgeCacheTest.js
+++ b/src/js/test/reducers/zonePurgeCacheTest.js
@@ -1,7 +1,6 @@
 import { expect } from 'chai';
 import { zonePurgeCacheReducer } from '../../reducers/zonePurgeCache';
 import * as ActionTypes from '../../constants/ActionTypes';
-import 'babel-polyfill'; //Object.Assign
 
 let initialState = {
     isFetching: false,

--- a/src/js/test/reducers/zoneRailgunTest.js
+++ b/src/js/test/reducers/zoneRailgunTest.js
@@ -1,7 +1,6 @@
 import { expect } from 'chai';
 import { zoneRailgunReducer } from '../../reducers/zoneRailgun';
 import * as ActionTypes from '../../constants/ActionTypes';
-import 'babel-polyfill'; //Object.Assign
 
 const initialState = {
     entities: {},

--- a/src/js/test/selectors/configTest.js
+++ b/src/js/test/selectors/configTest.js
@@ -1,7 +1,6 @@
 import { expect } from 'chai';
 import { getAbsoluteUrl, getConfigValue } from '../../selectors/config';
 import { ABSOLUTE_URL_BASE_KEY } from '../../reducers/config.js';
-import 'babel-polyfill'; //Object.Assign
 
 describe('Config Selector', () => {
     it('getAbsoluteUrl should concatenate the absolute URL', () => {


### PR DESCRIPTION
I couldn't find a place where `transform-object-assign` plugin was useful. We weren't using any of the plugins where `loose: true` was set.

I'd expect stuff to break but I've compiled, tested and everything seemed to work. 

In package.json do we need to remove `babel-polyfill`? I couldn't find a place where we were using it. It was imported in tests but I don't think it's being used.

```
    "babel-polyfill": "^6.5.0"
```